### PR TITLE
add: ログイン画面の作成

### DIFF
--- a/src/front/app/globals.css
+++ b/src/front/app/globals.css
@@ -2,26 +2,3 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
-body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
-}

--- a/src/front/components/default_button.tsx
+++ b/src/front/components/default_button.tsx
@@ -1,0 +1,19 @@
+interface DefaultButtonProps {
+  value: string;
+  type: "submit" | "button" | "reset";
+  blueDensity?: number;
+};
+
+const DefaultButton: React.FC<DefaultButtonProps> = ({ value, type, blueDensity = 600}) => {
+  const hoverBlueDensity = blueDensity - 100
+  return (
+    <button
+      type={type}
+      className={`flex w-full justify-center rounded-md bg-indigo-${blueDensity} px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-${hoverBlueDensity} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-bg-indigo-${blueDensity}`}
+    >
+      {value}
+    </button>
+  );
+}
+
+export default DefaultButton;

--- a/src/front/components/default_button.tsx
+++ b/src/front/components/default_button.tsx
@@ -1,19 +1,16 @@
 interface DefaultButtonProps {
   value: string;
   type: "submit" | "button" | "reset";
-  blueDensity?: number;
 };
 
-const DefaultButton: React.FC<DefaultButtonProps> = ({ value, type, blueDensity = 600}) => {
-  const hoverBlueDensity = blueDensity - 100
+export const DefaultButton: React.FC<DefaultButtonProps> = ({ value, type }) => {
+
   return (
     <button
       type={type}
-      className={`flex w-full justify-center rounded-md bg-indigo-${blueDensity} px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-${hoverBlueDensity} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-bg-indigo-${blueDensity}`}
+      className={`flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-bg-indigo-600`}
     >
       {value}
     </button>
   );
 }
-
-export default DefaultButton;

--- a/src/front/components/input_field.tsx
+++ b/src/front/components/input_field.tsx
@@ -3,7 +3,7 @@ interface InputFieldProps {
   dataName: string;
 };
 
-const InputField: React.FC<InputFieldProps> = ({ value, dataName} ) => {
+export const InputField: React.FC<InputFieldProps> = ({ value, dataName } ) => {
   return (
     <div>
       <div className="flex items-center justify-between">
@@ -22,5 +22,3 @@ const InputField: React.FC<InputFieldProps> = ({ value, dataName} ) => {
     </div>
   );
 }
-
-export default InputField;

--- a/src/front/components/input_field.tsx
+++ b/src/front/components/input_field.tsx
@@ -1,0 +1,26 @@
+interface InputFieldProps {
+  value: string;
+  dataName: string;
+};
+
+const InputField: React.FC<InputFieldProps> = ({ value, dataName} ) => {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <label htmlFor={dataName} className="block text-sm font-medium leading-6 text-gray-900">{value}</label>
+      </div>
+      <div className="mt-2">
+        <input
+          id={dataName}
+          name={dataName}
+          type={dataName}
+          autoComplete="current-password"
+          required
+          className="block w-full rounded-md border-0 p-1.5  text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default InputField;

--- a/src/front/components/layout.tsx
+++ b/src/front/components/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+interface LayoutProps {
+  children: ReactNode;
+};
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  return (
+    <div className="h-screen w-screen flex justify-center items-center">
+      {children}
+    </div>
+  );
+}
+
+export default Layout;

--- a/src/front/components/layout.tsx
+++ b/src/front/components/layout.tsx
@@ -4,12 +4,10 @@ interface LayoutProps {
   children: ReactNode;
 };
 
-const Layout: React.FC<LayoutProps> = ({ children }) => {
+export const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <div className="h-screen w-screen flex justify-center items-center">
       {children}
     </div>
   );
 }
-
-export default Layout;

--- a/src/front/pages/_app.js
+++ b/src/front/pages/_app.js
@@ -1,0 +1,8 @@
+import '../app/globals.css';
+import React from 'react';
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/src/front/pages/signin.tsx
+++ b/src/front/pages/signin.tsx
@@ -1,6 +1,6 @@
-import DefaultButton from '../components/default_button';
-import InputField from '../components/input_field';
-import Layout from '../components/layout';
+import { DefaultButton }  from '../components/default_button';
+import { InputField } from '../components/input_field';
+import { Layout}  from '../components/layout';
 
 const LoginForm = () => {
   return (

--- a/src/front/pages/signin.tsx
+++ b/src/front/pages/signin.tsx
@@ -1,0 +1,36 @@
+import DefaultButton from '../components/default_button';
+import InputField from '../components/input_field';
+import Layout from '../components/layout';
+
+const LoginForm = () => {
+  return (
+    <Layout>
+      <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+        <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+          <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Login</h2>
+        </div>
+        <form className="space-y-6" action="#" method="POST">
+          <div>
+            <InputField value='Email Adress' dataName='email'/>
+          </div>
+
+          <div>
+            <InputField value='Password' dataName='password'/>
+          </div>
+
+          <div>
+            <div className='mt-14'>
+              <DefaultButton value='Signin' type='submit'/>
+            </div>
+          </div>
+        </form>
+
+        <p className="mt-3 text-center text-sm text-gray-500">
+          <a href="#" className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">新規会員登録はこちら</a>
+        </p>
+      </div>
+    </Layout>
+  );
+}
+
+export default LoginForm;


### PR DESCRIPTION
# 実装内容
ログイン画面の作成
![ログイン画面](https://github.com/sayasurvey/company_book_mgt/assets/89208789/b0a4b2e4-3750-47cd-9b3f-edf9688de433)

# 検証方法
URL: http://localhost:3011/signin
メールアドレスとパスワードに文字を入力することを確認

# 設計書
https://discord.com/channels/1134843973098295318/1148968663001608254/1151177177182765087

# 備考
APIを作成していないので画面作成のみです
CSSフレームワークはTailwindを使用しています

## コンポーネントの説明
- Layout
　画面の中央にBodyを表示させるためのもの
- DefaultButton
　サインインボタンなど通常使用するボタン
　色は青のみ
　引数の説明
　　value: 表示する文字
　　type: buttonタグのtypeの指定
　　blueDensity: 青の濃さ
- InputField
　メールアドレスやパスワードなどの入力フォーム
　引数の説明
　　value: ラベルに表示する文字列
　　dataName: idやname, typeに指定する文字列(typeの指定で不具合が発生した場合は修正します)
