### PR TITLE
add: サインアップ画面の作成

### DIFF
--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -2,15 +2,19 @@ import { DefaultButton }  from '../components/default_button';
 import { InputField } from '../components/input_field';
 import { Layout}  from '../components/layout';
 
-const LoginForm = () => {
+const SignupForm = () => {
   return (
     <Layout>
       <div className="h-screen w-screen flex justify-center items-center">
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
           <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-            <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">サインイン</h2>
+            <h2 className="text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">アカウント作成</h2>
           </div>
           <form className="space-y-6" action="#" method="POST">
+            <div>
+              <InputField value='ニックネーム' dataName='nickname'/>
+            </div>
+
             <div>
               <InputField value='メールアドレス' dataName='email'/>
             </div>
@@ -21,13 +25,13 @@ const LoginForm = () => {
 
             <div>
               <div className='mt-2'>
-                <DefaultButton value='サインイン' type='submit'/>
+                <DefaultButton value='登録' type='submit'/>
               </div>
             </div>
           </form>
 
           <p className="mt-3 text-center text-sm text-gray-500">
-            <a href="/signup" className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">新規会員登録はこちら</a>
+            <a href="/signin" className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">サインインはこちら</a>
           </p>
         </div>
       </div>
@@ -35,4 +39,4 @@ const LoginForm = () => {
   );
 }
 
-export default LoginForm;
+export default SignupForm;


### PR DESCRIPTION
# 修正内容
- サインアップ画面の追加
![ScreenShot](https://github.com/sayasurvey/company_book_mgt_front/assets/89208789/186edf4c-1223-4454-9de4-fe5774f000e8)
- サインイン画面の修正
![ScreenShot](https://github.com/sayasurvey/company_book_mgt_front/assets/89208789/841593b6-7473-405f-9885-ef60fa6690f1)

# 検証方法
URL: http://localhost:3011/signup

# 仕様書
https://discord.com/channels/1134843973098295318/1148968663001608254/1153323278753071265

# 備考
APIを作成していないので画面作成のみです
CSSフレームワークはTailwindを使用しています
